### PR TITLE
Add :css-prepend option to allow easy inclusion of raw css resources - normalize.css etc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,15 +54,15 @@ In your `build.boot` you could call it like this:
 
 ## Options
 
-See the [boot project](https://github.com/boot-clj/boot) for more information
-on how to use these.
+See the [boot project](https://github.com/boot-clj/boot) for more information on how to use these. To view these options on the command line, use `boot garden --help`.
 
 ```clojure
-[o output-to PATH      str   "The output css file path relative to target/"
+[o output-to PATH      str   "The output css file path relative to docroot"
  s styles-var SYM      sym   "The var containing garden rules"
  p pretty-print        bool  "Pretty print compiled CSS"
- v vendors NAME        [str] "Vendors to apply prefixes for"
- a auto-prefix NAME    [str] "Properties to auto-prefix with vendor-prefixes"]
+ v vendors VENDORS     [str] "Vendors to apply prefixes for"
+ c css-prepend PREPEND [str] "Raw CSS from resources to be prepended to the output"
+ a auto-prefix PREFIX  #{kw} "Properties to auto-prefix with vendor-prefixes"]
 ```
 
 By default `boot-garden` will materialize the compiled CSS file on the fileset, and, as per [Boot's FAQ](https://github.com/boot-clj/boot/wiki/FAQ), will save it to `target/main.css` only when the `target` task ends the pipeline.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Provides the `garden` task, which compiles Garden to CSS.
 
 [](dependency)
 ```clojure
-[org.martinklepsch/boot-garden "1.3.2-0"] ;; latest release
+[org.martinklepsch/boot-garden "1.3.2-1"] ;; latest release
 ```
 [](/dependency)
 

--- a/build.boot
+++ b/build.boot
@@ -5,7 +5,7 @@
 
 (require '[adzerk.bootlaces :refer [bootlaces! build-jar push-release]])
 
-(def +version+ "1.3.2-0")
+(def +version+ "1.3.2-1")
 
 (bootlaces! +version+)
 

--- a/example/build.boot
+++ b/example/build.boot
@@ -1,10 +1,12 @@
 (set-env!
  :source-paths #{"src"}
- :dependencies '[[org.martinklepsch/boot-garden "1.3.0-0"]
+ :resource-paths #{"resources"}
+ :dependencies '[[org.martinklepsch/boot-garden "1.3.2-1"]
                  [org.clojure/data.json "0.2.6"]])
 
 (require '[org.martinklepsch.boot-garden :refer [garden]])
 
 (task-options! garden {:styles-var   'stylesheet/combined
                        :output-to    "public/css/garden.css"
+                       :css-prepend  ["css/prepend1.css" "css/prepend2.css"]
                        :pretty-print false})

--- a/example/resources/css/prepend1.css
+++ b/example/resources/css/prepend1.css
@@ -1,0 +1,3 @@
+body {
+  background: blue;
+}

--- a/example/resources/css/prepend2.css
+++ b/example/resources/css/prepend2.css
@@ -1,0 +1,3 @@
+h1 {
+  font-size: 20em;
+}

--- a/src/org/martinklepsch/boot_garden.clj
+++ b/src/org/martinklepsch/boot_garden.clj
@@ -21,7 +21,9 @@
   (pod/pod-pool (add-dep (boot/get-env) '[garden "1.3.2"])
                 :init (fn [pod] (pod/require-in pod 'garden.core))))
 
-(defn css-prepend-resources [out css-prepend]
+(defn- css-prepend-resources [out css-prepend]
+  "Prepend the output file with each resource in the array `css-prepend`,
+   before compiling the css"
   (with-open [os (io/output-stream out)]
     (doseq [p css-prepend]
       (if-let [p-resource (io/resource p)]

--- a/src/org/martinklepsch/boot_garden.clj
+++ b/src/org/martinklepsch/boot_garden.clj
@@ -34,11 +34,11 @@
 
 (deftask garden
   "compile garden"
-  [o output-to PATH      str   "The output css file path relative to docroot."
+  [o output-to PATH      str   "The output css file path relative to docroot"
    s styles-var SYM      sym   "The var containing garden rules"
    p pretty-print        bool  "Pretty print compiled CSS"
-   v vendors VENDORS     [str] "Vendors to apply prefixed for"
-   c css-prepend PREPEND [str] "CSS resources to be prepended to output"
+   v vendors VENDORS     [str] "Vendors to apply prefixes for"
+   c css-prepend PREPEND [str] "Raw CSS from resources to be prepended to the output"
    a auto-prefix PREFIX  #{kw} "Properties to auto-prefix with vendor-prefixes"]
 
   (let [output-path (or output-to "main.css")


### PR DESCRIPTION
Often on a per-file basis, I want to include some raw css. For example, `normalize.css`, a grid system, bootstrap etc. This pull request begins by appending the specified files from the `resources` directory, and then adding the garden generated css to the end of the file. 