### PR TITLE
Fix #95, use built in preamble option, bump garden version.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Provides the `garden` task, which compiles Garden to CSS.
 
 [](dependency)
 ```clojure
-[org.martinklepsch/boot-garden "1.3.2-1"] ;; latest release
+[org.martinklepsch/boot-garden "1.3.2-2"] ;; latest release
 ```
 [](/dependency)
 

--- a/build.boot
+++ b/build.boot
@@ -5,7 +5,7 @@
 
 (require '[adzerk.bootlaces :refer [bootlaces! build-jar push-release]])
 
-(def +version+ "1.3.2-1")
+(def +version+ "1.3.2-2")
 
 (bootlaces! +version+)
 

--- a/example/build.boot
+++ b/example/build.boot
@@ -1,7 +1,7 @@
 (set-env!
  :source-paths #{"src"}
  :resource-paths #{"resources"}
- :dependencies '[[org.martinklepsch/boot-garden "1.3.2-1"]
+ :dependencies '[[org.martinklepsch/boot-garden "1.3.2-2"]
                  [org.clojure/data.json "0.2.6"]])
 
 (require '[org.martinklepsch.boot-garden :refer [garden]])


### PR DESCRIPTION
It seems I overlooked the builtin `:preamble` option when trying to add the css prepending - and caused the compiled file to grow indefinitely when nothing was prepended. This should revert the changes I made, by using the built in prepend option.